### PR TITLE
Add FPGA supported Riscv with h-extension based on Rocketchip and now can boot riscv64 Linux.

### DIFF
--- a/docs/2024/20240706_FPGA_Supported_Rocketchip.md
+++ b/docs/2024/20240706_FPGA_Supported_Rocketchip.md
@@ -1,0 +1,82 @@
+# FPGA zcu102
+
+Author: 杨竣轶(Jerry) github.com/comet959
+
+```shell
+# Before, Install vivado 2022.2 software
+# Ubuntu 20.04 can work fine
+sudo apt update
+
+git clone https://github.com/U-interrupt/uintr-rocket-chip.git
+cd uintr-rocket-chip
+git submodule update --init --recursive
+export RISCV=/opt/riscv64
+git checkout 98e9e41
+vim digilent-vivado-script/config.ini # Env Config
+
+make checkout
+make clean
+make build
+
+# Use vivado to open the vivado project, then change the top file, run synthesis, run implementation, generate bitstream.
+# Connect the zcu102 - Jtag and Uart on your PC.
+# Use dd command to flash the image include boot and rootfs part.
+# Change the boot button mode to (On Off Off Off)
+# Boot the power.
+
+sudo screen /dev/ttyUSB0 115200 # Aarch64 Core Uart
+sudo screen /dev/ttyUSB2 115200 # Riscv Core Uart
+
+# On /dev/ttyUSB0
+cd uintr-rocket-chip
+./load-and-reset.sh
+
+# Focus on ttyUSB2, then you will see the Riscv Linux Boot Msg.
+
+```
+
+
+
+## 在RocketChip中开启H扩展
+
+```shell
+vim path/to/repo/common/src/main/scala/Configs.scala
+```
+
+```scala
+// change
+class UintrConfig extends Config(
+  new WithNBigCores(4) ++
+    new WithNExtTopInterrupts(6) ++
+    new WithTimebase((BigInt(10000000))) ++ // 10 MHz
+    new WithDTS("freechips.rocketchip-unknown", Nil) ++
+    new WithUIPI ++
+    new WithCustomBootROM(0x10000, "../common/boot/bootrom/bootrom.img") ++
+    new WithDefaultMemPort ++
+    new WithDefaultMMIOPort ++
+    new WithDefaultSlavePort ++
+    new WithoutTLMonitors ++
+    new WithCoherentBusTopology ++
+    new BaseSubsystemConfig
+)
+
+// to
+
+class UintrConfig extends Config(
+  new WithHypervisor ++
+  new WithNBigCores(4) ++
+    new WithNExtTopInterrupts(6) ++
+    new WithTimebase((BigInt(10000000))) ++ // 10 MHz
+    new WithDTS("freechips.rocketchip-unknown", Nil) ++
+    new WithUIPI ++
+    new WithCustomBootROM(0x10000, "../common/boot/bootrom/bootrom.img") ++
+    new WithDefaultMemPort ++
+    new WithDefaultMMIOPort ++
+    new WithDefaultSlavePort ++
+    new WithoutTLMonitors ++
+    new WithCoherentBusTopology ++
+    new BaseSubsystemConfig
+)
+
+```
+

--- a/docs/2024/_sidebar.md
+++ b/docs/2024/_sidebar.md
@@ -1,3 +1,4 @@
+- [使用zcu102FPGA启动Rocketchip并启动Riscv Linux](20240706_FPGA_Supported_Rocketchip.md)
 - [在QEMU上运行riscv hvisor](20240613_Run_riscv_hvisor.md)
 - [hvisor的初始化过程](20240522_hvisor_initialization.md)
 - [在hvisor上使用Virtio设备](20240415_Virtio_devices_tutorial.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,15 @@
 # 矽望社区技术博客文章节选
 
+## ZCU102 FPGA launch RocketChip with H-extension and Boot Riscv64 Linux.
+
+**时间：** 2024年7月8日
+
+**作者：** 杨竣轶
+
+摘要：一份在ZCU102上启动RocketChip + H-extension + Riscv64 Linux的操作手册。
+
+[正文](2024/20240706_FPGA_Supported_Rocketchip.md)
+
 ## 在hvisor上使用Virtio磁盘和网络设备
 
 时间：2024年4月15日

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,3 +1,4 @@
+- [使用zcu102FPGA启动Rocketchip并启动Riscv Linux](2024/20240706_FPGA_Supported_Rocketchip.md)
 - [在hvisor上使用Virtio设备](2024/20240415_Virtio_devices_tutorial.md)
 - [RISC-V APLIC 介绍](2024/20240311_APLIC.md)
 - [在RuxOS上支持c++](2024/20240229_Support_c++_on_RuxOS.md)


### PR DESCRIPTION
docs/2024/20240706_FPGA_Supported_Rocketchip.md: Add FPGA supported Riscv with h-extension based on Rocketchip and now can boot riscv64 Linux.