### PR TITLE
Successfully build the h-extension rocketchip and run Linux.

### DIFF
--- a/docs/2024/20240706_FPGA_Supported_Rocketchip.md
+++ b/docs/2024/20240706_FPGA_Supported_Rocketchip.md
@@ -348,7 +348,7 @@ ls -lh arch/riscv/boot/Image
                         compatible = "riscv,uintc0";
                         interrupt-controller;
                         interrupts-extended = <&L2 0 &L5 0 &L3 0 &L20 0>;
-                        reg = <0x0 0x3000000 0x0 0x400>;
+                        reg = <0x0 0x3000000 0x0 0x1000>;
                         reg-names = "control";
                 };
                 L17: serial@60000000 {


### PR DESCRIPTION

Please track this issue to check my work.

https://github.com/BOSC-Hvisor/hvisor-rocket-chip/issues/3


Next time, i would boot Linux with kvm.